### PR TITLE
add required privileges to process in service file

### DIFF
--- a/etc/systemd/poppassd.service
+++ b/etc/systemd/poppassd.service
@@ -46,5 +46,6 @@ SystemCallFilter=~@privileged @resources
 RestrictAddressFamilies=~AF_INET AF_INET6 AF_PACKET AF_UNIX AF_NETLINK
 CapabilityBoundingSet=
 
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
SystemcallFilter "@privileged" removes chown capability/systemcall from process which it requires
AF_UNIX <- syslog
AF_NETLINK <-  NETLINK_AUDIT kernel audit system
ReadWritePaths=/etc  <- obvious one :)
CapabilityBoundingSet=CAP_CHOWN <- pam handling changes of /etc/shadow ownership requires it