### PR TITLE
add required privileges to process in service file

### DIFF
--- a/etc/systemd/poppassd.service
+++ b/etc/systemd/poppassd.service
@@ -42,9 +42,10 @@ DeviceAllow=
 IPAddressDeny=any
 ProtectHome=yes
 SystemCallFilter=@basic-io
-SystemCallFilter=~@privileged @resources
-RestrictAddressFamilies=~AF_INET AF_INET6 AF_PACKET AF_UNIX AF_NETLINK
-CapabilityBoundingSet=
+SystemCallFilter=~@resources
+RestrictAddressFamilies=~AF_INET AF_INET6 AF_PACKET
+CapabilityBoundingSet=CAP_CHOWN
+ReadWritePaths=/etc
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
SystemcallFilter "@PRIVILEGED" removes chown capability/systemcall from process which it requires
AF_UNIX <- syslog
AF_NETLINK <- NETLINK_AUDIT kernel audit system
ReadWritePaths=/etc <- obvious one :)
CapabilityBoundingSet=CAP_CHOWN <- pam handling changes of /etc/shadow ownership requires it